### PR TITLE
Replacing debug_msg with warn and restructure module

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Puppetfile entries
     # Directly from Git
     mod 'azuremetadata',
         :git => 'https://github.com/keirans/azuremetadata.git',
-        :tag => '0.1.2'
+        :tag => '0.1.3'
 
     
     # Directly from the forge
-    mod 'keirans-azuremetadata', '0.1.2'
+    mod 'keirans-azuremetadata', '0.1.3'
 
 
 Role / Profile inclusion

--- a/lib/facter/azure_metadata.rb
+++ b/lib/facter/azure_metadata.rb
@@ -16,15 +16,16 @@ begin
   url_metadata = 'http://169.254.169.254/metadata/instance?api-version=2017-08-01'
   metadataraw = open(url_metadata, 'Metadata' => 'true', proxy: false).read
   metadata = JSON.parse(metadataraw)
-rescue
-  debug_msg("This is not an Azure instance or unable to contact the Azure instance-data web server.")
-end
 
-Facter.add(:az_metadata) do
-  confine virtual: 'hyperv'
-  setcode do
-    tags = metadata['compute']['tags'].split(';')
-    metadata['compute']['tags'] = Hash[tags.map { |tag| tag.split(':') }]
-    metadata
+  Facter.add(:az_metadata) do
+    confine virtual: 'hyperv'
+    setcode do
+      tags = metadata['compute']['tags'].split(';')
+      metadata['compute']['tags'] = Hash[tags.map { |tag| tag.split(':') }]
+      metadata
+    end
   end
+
+rescue
+  warn 'Unable to resolve az_metadata - This is not an Azure instance or unable to contact the Azure instance-data web server.'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "keirans-azuremetadata",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "keirans",
   "summary": "This Puppet module exposes the Azure instance metadata as facts",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Replacing debug_msg with warn for failures and moving the fact creation into the begin block so it is only created if metadata can be retrieved
- Minor version bump