### PR TITLE
(DO NOT MERGE) (feature) Fixed confine to use new cloud fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,6 @@ You can then reference these values in your Puppet code using the facts hash suc
 
 ## Limitations
 
-### Fact containment to Azure only environments
-Currently, there is no consistent way to contain the fact to Azure public cloud environments only, as such, the fact is only exposed when the virtual fact is of value  hyperv, however, if you are using both hyperv and azure environments this may cause some issues for you as the API query will time out.
-
-The main challenge here is that the cloud fact would help more effectively doesnt support anything but Linux right now. 
-This is issue is tracked in JIRA: 
-* [FACT-1441 - Add "cloud" fact that identifies Azure](https://tickets.puppetlabs.com/browse/FACT-1441)
-
 ### API version pinned to 2017-12-01
 Version 0.1.5 is currently using API version 2017-12-01, I'll update this as new versions become available and bump the module version accordingly.
 

--- a/lib/facter/azure_metadata.rb
+++ b/lib/facter/azure_metadata.rb
@@ -5,16 +5,15 @@
 # This fact exposes the Azure metadata as a Puppet fact in the az_metadata
 # namespace.
 #
-# As there is no consistent way to contain the fact to azure right now we
-# do it to hyperv for the time being. See the README for more information.
-#
 
 require 'open-uri'
 require 'json'
 
 begin
   Facter.add(:az_metadata) do
-    confine :virtual => 'hyperv'
+    confine :cloud do |value|
+      value['provider'] == 'azure'
+    end
     setcode do
       url_metadata = 'http://169.254.169.254/metadata/instance?api-version=2017-12-01'
       metadataraw = open(url_metadata, 'Metadata' => 'true', proxy: false).read


### PR DESCRIPTION
This PR Fixes #14.  There is now a cloud fact we can use to actually determine if a node is in azure instead of being in a state where it could be in azure or could be in hyperv.