### PR TITLE
Updating module feedback based on issues and recent PR's

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@
 
 ## Description
 
-[Azure now has an instance metadata service that is GA globally !](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-instancemetadataservice-overview)
+[Azure now has an instance metadata service that is GA globally !](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service)
 
 To help with further automation, this modules exposes the Azure instance metadata as a structured fact for use in Puppet code.
 If you would like to see this end up in Facter Core, please do vote for the JIRA below:
 * [FACT-1383 - Azure Instance Metadata ](https://tickets.puppetlabs.com/browse/FACT-1383)
 
-This has been tested with Puppet Enterprise 2019.0 on Windows 2016 and RHEL 7, however it should work on any platform that has a modern Ruby with open-uri and JSON support.
+This has been tested with Puppet 6.17.0 RHEL8 , however it should work on any platform that has a modern Ruby with open-uri and JSON support.
 
-This module is part of a larger part of Puppet and Azure work that I presented at Puppetconf 2017.
+This module was part of a larger part of Puppet and Azure work that I presented at Puppetconf 2017.
 
 * [You can see the presentation video here.](https://www.youtube.com/watch?v=tbWeYvOHvJE)
 
@@ -37,11 +37,11 @@ Puppetfile entries
     # Directly from Git
     mod 'azuremetadata',
         :git => 'https://github.com/keirans/azuremetadata.git',
-        :tag => '0.1.9'
+        :tag => '0.2.0'
 
     
     # Directly from the forge
-    mod 'keirans-azuremetadata', '0.1.9'
+    mod 'keirans-azuremetadata', '0.2.0'
 
 
 ## Usage
@@ -54,8 +54,11 @@ Returning the full set of metadata from Facter on Windows
 PS> facter az_metadata
 {
   compute => {
-    location => "australiaeast",
-    name => "keiranpuppet",
+    azEnvironment => "AzurePublicCloud",
+    customData => "",
+    isHostCompatibilityLayerVm => "false",
+    location => "australiasoutheast",
+    name => "puppetdev",
     offer => "RHEL",
     osType => "Linux",
     placementGroupId => "",
@@ -66,23 +69,71 @@ PS> facter az_metadata
     },
     platformFaultDomain => "0",
     platformUpdateDomain => "0",
+    provider => "Microsoft.Compute",
     publicKeys => [
       {
-        keyData => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7OGhS/PGV7Ov6071BmaE2JnZs1J32zzdzkJD8Np6+1Uz/d7wFUHn4X76jbNlFJ78U5nr/i7WINmZ/rPkw+sLby/u95pwCeL28MiGvZWR7TKuRGb3QJTkWIoRUkJ6AH6IBMMoAbfwVlgEwP2nArJI4QS+euy7uHZONeYGXxUUsw37UYGtRHM+m62yURB8ZsNEzssMSu1/OLb5322RGubxFaT9QMOhaUcfvtCuO6MN3DmIuHCr9dlQV/c8HzztGW9YlMCd2Dcvbp9w+LcPYldGw/U8JVF+K2YHLKxBa5ZlB3+jC0KJG3HCnj+TJ2tc+MsLprdh5oCom/Mi3l/XOmpEr keiran@computer",
+        keyData => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7OGhS/PGV7Ov6071BmaE2JnZs1J32zzdzkJD8Np6+1Uz/d7wFUHn4X76jbNlFJ78U5nr/i7WINmZ/rPkw+sLby/u95pwCeL28MiGvZWR7TKuRGb3QJTkWIoRUkJ6AH6IBMMoAbfwVlgEwP2nArJI4QS+euy7uHZONeYGXxUUsw37UYGtRHM+m62yURB8ZsNEzssMSu1/OLb5322RGubxFaT9QMOhaUcfvtCuO6MN3DmIuHCr9dlQV/c8HzztGW9YlMCd2Dcvbp9w+LcPYldGw/U8JVF+K2YHLKxBa5ZlB3+jC0KJG3HCnj+TJ2tc+MsLprdh5oCom/Mi3l/XOmpEr keiran@Keirans-MacBook-Pro.local",
         path => "/home/keiran/.ssh/authorized_keys"
       }
     ],
     publisher => "RedHat",
-    resourceGroupName => "Puppet",
-    sku => "7.4",
-    subscriptionId => "0432b1bb-5e2e-4e2a-ad73-e33d0652eaaa",
-    tags => {
-      keiran => "testing"
+    resourceGroupName => "puppetdev_group",
+    resourceId => "/subscriptions/0432b1d0-5e2e-4e2a-ad73-e33d0652e3f7/resourceGroups/puppetdev_group/providers/Microsoft.Compute/virtualMachines/puppetdev",
+    securityProfile => {
+      secureBootEnabled => "false",
+      virtualTpmEnabled => "false"
     },
-    version => "7.4.2018010506",
-    vmId => "1e0e6c25-1578-4091-a49c-eeb74d070685",
+    sku => "82gen2",
+    storageProfile => {
+      dataDisks => [],
+      imageReference => {
+        id => "",
+        offer => "RHEL",
+        publisher => "RedHat",
+        sku => "82gen2",
+        version => "latest"
+      },
+      osDisk => {
+        caching => "ReadWrite",
+        createOption => "FromImage",
+        diffDiskSettings => {
+          option => ""
+        },
+        diskSizeGB => "64",
+        encryptionSettings => {
+          enabled => "false"
+        },
+        image => {
+          uri => ""
+        },
+        managedDisk => {
+          id => "/subscriptions/0432b1d0-5e2e-4e2a-ad73-e33d0652e3f7/resourceGroups/PUPPETDEV_GROUP/providers/Microsoft.Compute/disks/puppetdev_OsDisk_1_62a017170f4044adbcfea54cea6cc45d",
+          storageAccountType => "Premium_LRS"
+        },
+        name => "puppetdev_OsDisk_1_62a017170f4044adbcfea54cea6cc45d",
+        osType => "Linux",
+        vhd => {
+          uri => ""
+        },
+        writeAcceleratorEnabled => "false"
+      }
+    },
+    subscriptionId => "0432b1d0-5e2e-4e2a-ad73-e33d0652e3f7",
+    tags => "testtag1:thisisavalue1;testtag:2:thisisavalue2",
+    tagsList => [
+      {
+        name => "testtag1",
+        value => "thisisavalue1"
+      },
+      {
+        name => "testtag:2",
+        value => "thisisavalue2"
+      }
+    ],
+    version => "8.2.2020050812",
+    vmId => "976f831c-dc8d-446d-b62d-0598b77b5799",
     vmScaleSetName => "",
-    vmSize => "Standard_D2_v3",
+    vmSize => "Standard_D4s_v3",
     zone => ""
   },
   network => {
@@ -91,13 +142,13 @@ PS> facter az_metadata
         ipv4 => {
           ipAddress => [
             {
-              privateIpAddress => "10.0.0.4",
-              publicIpAddress => "104.210.68.73"
+              privateIpAddress => "10.5.0.4",
+              publicIpAddress => "52.189.236.160"
             }
           ],
           subnet => [
             {
-              address => "10.0.0.0",
+              address => "10.5.0.0",
               prefix => "24"
             }
           ]
@@ -105,7 +156,7 @@ PS> facter az_metadata
         ipv6 => {
           ipAddress => []
         },
-        macAddress => "000D3AD2B7B7"
+        macAddress => "00224814BABC"
       }
     ]
   }
@@ -126,17 +177,35 @@ You can then reference these values in your Puppet code using the facts hash suc
 
 ## Limitations
 
-### Fact containment to Azure only environments
-Currently, there is no consistent way to contain the fact to Azure public cloud environments only, as such, the fact is only exposed when the virtual fact is of value  hyperv, however, if you are using both hyperv and azure environments this may cause some issues for you as the API query will time out.
+### API version pinned to 2020-06-01
+Version 0.2.0 is currently using API version 2020-06-01, I'll update this as new versions become available and bump the module version accordingly.
 
-The main challenge here is that the cloud fact would help more effectively doesnt support anything but Linux right now. 
-This is issue is tracked in JIRA: 
-* [FACT-1441 - Add "cloud" fact that identifies Azure](https://tickets.puppetlabs.com/browse/FACT-1441)
+Please note that versions prior to 0.2.0 introduced a 'tags' key in the fact data, this now conflicts with a value in the metadata data itself from the Azure platform, as such it has been removed and you should use the tagsList value instead which is native functionaly. As a result, 0.2.0 is a breaking change for previous users.
 
-### API version pinned to 2018-04-02
-Version 0.1.9 is currently using API version 2018-04-02, I'll update this as new versions become available and bump the module version accordingly.
+This native approach also gracefully handles special characters in tag keys and values unlike previous versions of the module.
+
+
+```
+# facter  az_metadata.compute.tags
+testtag1:thisisavalue1;testtag:2:thisisavalue2
+# facter az_metadata.compute.tagsList
+[
+  {
+    name => "testtag1",
+    value => "thisisavalue1"
+  },
+  {
+    name => "testtag:2",
+    value => "thisisavalue2"
+  }
+]
+#
+```
 
 ## Development
-Happy to accept pull requests, I'd expect this to end up in Facter Core at some time in the future, then this can be deprecated.
+I'm no longer actively using Azure anymore, so updates can be a bit delayed, however I'm still Happy to accept pull requests, if you could make them easier for me to merge, that would be amazing, specifically ensuring that fixes bump the version number, update the metadata file and also the README so i don't have to. :) :) :)
+
+I'd expect this to end up in Facter Core at some time in the future, then this can be deprecated.
+
 Please do vote for this JIRA for its addition: 
 * [FACT-1383 - Azure Instance Metadata ](https://tickets.puppetlabs.com/browse/FACT-1383)

--- a/lib/facter/azure_metadata.rb
+++ b/lib/facter/azure_metadata.rb
@@ -12,18 +12,14 @@
 require 'open-uri'
 require 'json'
 
-begin
-  Facter.add(:az_metadata) do
-    confine :virtual => 'hyperv'
-    setcode do
-      url_metadata = 'http://169.254.169.254/metadata/instance?api-version=2018-04-02'
-      metadataraw = open(url_metadata, 'Metadata' => 'true', 'User-Agent' => 'Puppet', proxy: false).read
-      metadata = JSON.parse(metadataraw)
-      tags = metadata['compute']['tags'].split(';')
-      metadata['compute']['tags'] = Hash[tags.map { |tag| tag.split(':', 2) }]
-      metadata
-    end
+Facter.add(:az_metadata) do
+  confine :cloud do |cloud|
+    cloud['provider'] == 'azure'
   end
-rescue
-  warn 'Unable to resolve az_metadata - This is not an Azure instance or unable to contact the Azure instance-data web server.'
+  setcode do
+    url_metadata = 'http://169.254.169.254/metadata/instance?api-version=2020-06-01'
+    metadataraw = open(url_metadata, 'Metadata' => 'true', 'User-Agent' => 'Puppet', proxy: false).read
+    metadata = JSON.parse(metadataraw)
+    metadata
+  end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "keirans-azuremetadata",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "author": "keirans",
   "summary": "This Puppet module exposes the Azure instance metadata as facts",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 7.0.0"
+      "version_requirement": ">= 5.5.20 < 7.0.0"
     }
   ],
   "pdk-version": "1.4.1",


### PR DESCRIPTION
* Updating documentation to cover latest version of module and fix broken links
* Updating Metadata version to support more data and features
* Removing custom tag exposing logic as the metadata service natively exposes this and the custom logic collides with the native namespaces
* Confine code now uses the native cloud provider functionality in Facter so hyper-v isn't required
* Will bump to 0.2.0 as this represents some breaking changes to other users.